### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/Modpacks_Server/index.rst
+++ b/docs/source/Modpacks_Server/index.rst
@@ -8,24 +8,6 @@ Custom Modpacks (MyM)
    :maxdepth: 2
    
    1.6.4/agrarian_skies_plus
-   1.7.10/mineyourgalaxy
-   1.7.10/death_is_expected
-
-1.4.7
------
-
-.. toctree::
-   :glob:
-
-   1.4.7/*
-
-1.5.2
------
-
-.. toctree::
-   :glob:
-
-   1.5.2/*
 
 1.6.4
 -----
@@ -35,7 +17,6 @@ Custom Modpacks (MyM)
 
    1.6.4/*
 
-
 1.7.10
 ------
 
@@ -43,3 +24,6 @@ Custom Modpacks (MyM)
    :glob:
 
    1.7.10/*
+   
+1.8
+------


### PR DESCRIPTION
Removed some parts of the structure as they are no longer on the network. Beside that, I can not see the list of the packs in 1.6.4 and 1.7.10 but in 1.6 you might want to remove Monster and Horizons and in 1.7.10 you might want to remove Bevo's Tech pack, Death is expected, MineyourGalaxy? , modsauce, ftb resurrection and the dark trilogy.

Update on skyfactory from skyfactory 2 to skyfactory 2.5

Beside that it might be possible to add 1.8 to the list with skyblock on it as we are having that one as well.