### PR TITLE
Fixed typo

### DIFF
--- a/docs/source/Knowledge_Base/custom_built.rst
+++ b/docs/source/Knowledge_Base/custom_built.rst
@@ -143,7 +143,7 @@ Other
 
 Watchdog
 --------
-Our live monitoring system. If a server is getting into trouble it barks. Build for the Amdins, but public to everyone. Each server sends a heartbeat every 20 seconds including live information about its condition.
+Our live monitoring system. If a server is getting into trouble it barks. Build for the Admins, but public to everyone. Each server sends a heartbeat every 20 seconds including live information about its condition.
 
 * ``Heartbeat`` - Last server respond. 
 * ``P30/120/300/600`` - Average server performance over the last 30/120/300/600 seconds in percentage. (100% = 20TPS, 50% = 10TPS..)
@@ -154,9 +154,9 @@ Our live monitoring system. If a server is getting into trouble it barks. Build 
 * ``Staff`` - Amount of staff online, hover for details (red = staff with operator permissions). 
 * ``StaffSeen`` - Time passed since a staff member has been seen on this server.
 * ``Worlds`` - Amount of worlds present (does not mean loaded).
-* ``Chunks`` - Amount of chunks loaded across all worlds. <n>/p chunks per player with a 256 total tolerance removed (the overworld spawn is usually loaded).
-* ``Entities`` - Amount of entities (Animlas, Monster, Villager, Items on the ground..) loaded across all worlds. <n>/p entities per player with a 128 total tolerance removed (the overworld spawn is usually loaded).
-* ``TileEntities`` - Amount of tile entities (Machines, Chests, Cables/Conduits..) loaded across all worlds. <n>/p tile entities per player with a 256 total tolerance removed (the overworld spawn is usually loaded).
+* ``Chunks`` - Amount of chunks loaded across all worlds. /p chunks per player with a 256 total tolerance removed (the overworld spawn is usually loaded).
+* ``Entities`` - Amount of entities (Animlas, Monster, Villager, Items on the ground..) loaded across all worlds. /p entities per player with a 128 total tolerance removed (the overworld spawn is usually loaded).
+* ``TileEntities`` - Amount of tile entities (Machines, Chests, Cables/Conduits..) loaded across all worlds. /p tile entities per player with a 256 total tolerance removed (the overworld spawn is usually loaded).
 
 Watchdog can be found `here <https://mineyourmind.net/server-status.html>`_
 


### PR DESCRIPTION
"Build for the Amdins" -> Admins and some other more, may need some tweaking still the /p parts (didn't understand it myself)
