### PR TITLE
Fixed enigmatica IP and version

### DIFF
--- a/docs/source/Server_Ips/server_ips_1_12.rst
+++ b/docs/source/Server_Ips/server_ips_1_12.rst
@@ -8,7 +8,7 @@ Server Ip's 1.12.2
 Enigmatica 2: Expert (1.12.2)
 ^^^^^^^^^^^^^^^^^^^^^^^
 .. note:: This is highly experimental
-* ``enigmatica.mineyourmind.li`` - Version ``1.45``
+* ``enigmatica.mineyourmind.net`` - Version ``1.46``
 
 FTB Continuum (1.12.2)
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The IP was listed wrong, and it was still showing version 1.45 and not 1.46.